### PR TITLE
Add a --query-mode option to vSPCClient; increase LISTEN_BACKLOG

### DIFF
--- a/lib/admin.py
+++ b/lib/admin.py
@@ -97,12 +97,12 @@ class AdminProtocolClient(Poller):
             sockfile.flush()
             status = unpickler.load()
             if status == Q_VM_NOTFOUND:
-                if self.vm_name is not None:
+                if self.query_mode:
                     sys.stderr.write("The host '%s' couldn't find the vm '%s'.\n" % (self.host, self.vm_name))
-                    if not self.query_mode:
-                        sys.stderr.write("The host knows about the following VMs:\n")
-                        vm_list = unpickler.load()
-                        self.process_noninteractive(vm_list)
+                else:
+                    sys.stderr.write("The host knows about the following VMs:\n")
+                    vm_list = unpickler.load()
+                    self.process_noninteractive(vm_list)
                 return None
             elif status == Q_LOCK_BAD:
                 sys.stderr.write("The host doesn't understand how to give me a write lock\n")

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -221,9 +221,18 @@ class vSPCBackendMemory:
             if vers == 2:
                 vm_name = pickle.load(sockfile)
                 lock_mode = pickle.load(sockfile)
+                query_mode = pickle.load(sockfile)
                 vm = self.observed_vm_for_name(vm_name)
 
-                if vm is not None and \
+                if query_mode:
+                    if vm is not None:
+                        pickle.dump(Q_OK, sockfile)
+                        pickle.dump([{Q_NAME:vm.name, Q_UUID:vm.uuid, Q_PORT:vm.port}], sockfile)
+                    else:
+                        pickle.dump(Q_VM_NOTFOUND, sockfile)
+                    sockfile.flush()
+                    return
+                elif vm is not None and \
                    lock_mode in (Q_LOCK_EXCL, Q_LOCK_WRITE, Q_LOCK_FFA, Q_LOCK_FFAR):
                     status = Q_LOCK_FAILED
                     with vm.modification_lock:

--- a/lib/server.py
+++ b/lib/server.py
@@ -46,7 +46,7 @@ from telnetlib import BINARY, SGA, ECHO
 from vSPC.poll import Poller
 from vSPC.telnet import TelnetServer, VMTelnetServer, VMExtHandler, hexdump
 
-LISTEN_BACKLOG = 5
+LISTEN_BACKLOG = 128 # match the default SOMAXCONN value to max performance
 
 def openport(port, iface="", use_ssl=False, ssl_cert=None, ssl_key=None):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/lib/telnet.py
+++ b/lib/telnet.py
@@ -347,7 +347,7 @@ class VMTelnetServer(TelnetServer):
                 "%s, uri: %s), will not proxy for this VM", dir, uri)
 
     def _handle_vmotion_begin(self, data):
-        cookie = data + struct.pack("i", hash(self) & 0xFFFFFFFF)
+        cookie = data + struct.pack("I", hash(self) & 0xFFFFFFFF)
 
         if self.handler.handle_vmotion_begin(self, cookie):
             logging.debug("vMotion initiated: %s", hexdump(cookie))

--- a/vSPCClient
+++ b/vSPCClient
@@ -33,8 +33,9 @@ from vSPC.admin import AdminProtocolClient, Q_LOCK_FFAR, Q_LOCK_FFA, Q_LOCK_WRIT
 # Default for --admin-port, the port to hit vSPC-query with
 ADMIN_PORT = 13371
 
-def do_query(host, port, vm_name, lock_mode):
-    client = AdminProtocolClient(host, port, vm_name, sys.stdin, sys.stdout, lock_mode)
+
+def do_query(host, port, vm_name, lock_mode, query_mode):
+    client = AdminProtocolClient(host, port, vm_name, sys.stdin, sys.stdout, lock_mode, query_mode)
     client.run()
 
 def check_lock_mode(option, opt_str, value, parser):
@@ -67,6 +68,8 @@ def main():
                       help="port to connect to on the server")
     parser.add_option("-d", "--debug", action='store_true', default=False,
                       help="debug mode; print to stdout, don't log to syslog")
+    parser.add_option("-q", "--query-mode", action='store_true', dest='query_mode', default=False,
+                      help="only show port number when a vm name or uuid is given")
     parser.add_option("--stdout", action='store_false', dest='syslog', default=True,
                       help="log to stdout instead of syslog")
     parser.add_option("-s", dest='remote_host', default="localhost",
@@ -92,7 +95,7 @@ def main():
         vm_name = args[0]
 
     return do_query(options.remote_host, options.admin_port, vm_name,
-                    options.client_lock_mode)
+                    options.client_lock_mode, options.query_mode)
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
This will query a vm and return only that vm's output. When there are hundreds or even thousands of vms, this command make it simple to figure out the tcp port of a specific VM.

Default LISTEN_BACKLOG in server is 5. This is a bottle neck when server starts and there are many vms connect to it at once. Increase to 128 will make it scale better.
