### PR TITLE
PR to upstream features and fixes from Cisco fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+#lib/
+#lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ If '--backend Foo' is given but no builtin backend Foo exists, vSPC.py
 tries to import module vSPCBackendFoo, looking for class vSPCBackendFoo.
 Use --help with the desired --backend for help using that backend.
 
+The environment variable VM_CLIENT_LIMIT can be set to a positive
+integer, in which case only VM_CLIENT_LIMIT clients can be connected
+to a VM at once.
+
 # Building the distribution
 
 source distribution

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ vSPC.py server
 - Clients can connect using standard telnet, binary mode is negotiated
 automatically
 - Support VMs with multiple serial ports
+- Support limiting the number of clients which can connect to a VM, e.g.
+you can allow only one client to be connected to a VM at a time
+- Support port clear command through admin interface, which disconnects
+all clients for a VM
 
 # Lineage
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ connections terminate
 vSPC.py server
 - Clients can connect using standard telnet, binary mode is negotiated
 automatically
+- Support VMs with multiple serial ports
 
 # Lineage
 
@@ -37,7 +38,7 @@ off to Paul B. Henson (https://github.com/pbhenson) to maintain.
 
 # Requirements
 
-Python 3.5 or greater is required.
+Python 3.6 or greater is required.
 
 Due to the use of epoll in the server implementation, Linux is required.
 There may be other issues associated with using vSPC.py on other OSs, as
@@ -55,11 +56,11 @@ follows:
 ```
     (*) Use Network
       (*) Server
-      Port URI: vSPC.py
+      Port URI: s0
       [X] Use Virtual Serial Port Concentrator:
       vSPC: telnet://hostname:proxy_port
 ```
-NOTE: Direction MUST be Server, and Port URI MUST be vSPC.py. 
+NOTE: Direction MUST be Server.
 
 where hostname is the FQDN (or IP address) of the machine running the
 virtual serial port concentrator, and proxy_port is the port that you've
@@ -69,6 +70,15 @@ TLS/SSL, configure the serial port as above, except for the vSPC field,
 which should specify telnets instead of telnet. For this to work
 correctly, you'll also need to launch the server with the --ssl, --cert,
 and possibly --key options.
+
+An arbitrary string can be chosen for "Port URI", but note that "_" is
+a restricted character. To support VMs with multiple serial ports,
+export the environment variable SUPPORT_MULTI_CONSOLE as "true" to
+enable the feature. This tells the VSPC to automatically add the Port
+URI as a suffix to the VM name and UUID, which yields identifiers that
+are unique per serial port. Port URIs under a single device should be
+unique, but dont need to be unique globally. A suggested convention is
+to choose "s0" for the first serial port, "s1" for the 2nd, etc.
 
 # Running the Concentrator
 

--- a/lib/admin.py
+++ b/lib/admin.py
@@ -221,7 +221,8 @@ class AdminProtocolClient(Poller):
             out = "%s:%s" % (vm[Q_NAME], vm[Q_UUID])
             if vm[Q_PORT] is not None:
                 out += ":%d" % vm[Q_PORT]
-            print(out)
+            self.destination.write(out)
+            self.destination.write("\n")
 
     def prepare_terminal(self):
         (oldterm, oldflags) = prepare_terminal(self.command_source)

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -45,7 +45,7 @@ from vSPC.admin import Q_VERS, Q_NAME, Q_UUID, Q_PORT, Q_OK, Q_VM_NOTFOUND, Q_LO
 
 class vSPCBackendMemory:
     ADMIN_THREADS = 4
-    ADMIN_CONN_TIMEOUT = 0.2
+    ADMIN_CONN_TIMEOUT = 10
 
     class OVm:
         def __init__(self, uuid = None, port = None, name = None):

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -42,11 +42,9 @@ import threading
 import queue
 
 from vSPC.admin import Q_VERS, Q_NAME, Q_UUID, Q_PORT, Q_OK, Q_VM_NOTFOUND, Q_LOCK_EXCL, Q_LOCK_WRITE, Q_LOCK_FFA, Q_LOCK_FFAR, Q_LOCK_BAD, Q_LOCK_FAILED
+from vSPC import settings
 
 class vSPCBackendMemory:
-    ADMIN_THREADS = 4
-    ADMIN_CONN_TIMEOUT = 10
-
     class OVm:
         def __init__(self, uuid = None, port = None, name = None):
             self.uuid = uuid
@@ -87,7 +85,7 @@ class vSPCBackendMemory:
         return th
 
     def start(self):
-        for i in range(0, self.ADMIN_THREADS):
+        for i in range(0, settings.ADMIN_THREADS):
             self.admin_threads.append(self._start_thread(self.admin_run))
 
         self.observer_thread = self._start_thread(self.observer_run)
@@ -196,7 +194,7 @@ class vSPCBackendMemory:
         self.admin_queue.put(lambda: self.handle_query_socket(sock, vspc))
 
     def handle_query_socket(self, sock, vspc):
-        sock.settimeout(self.ADMIN_CONN_TIMEOUT)
+        sock.settimeout(settings.ADMIN_CONN_TIMEOUT)
         sockfile = sock.makefile("rwb")
 
         # Trade versions

--- a/lib/server.py
+++ b/lib/server.py
@@ -45,6 +45,7 @@ from telnetlib import BINARY, SGA, ECHO
 
 from vSPC.poll import Poller
 from vSPC.telnet import TelnetServer, VMTelnetServer, VMExtHandler, hexdump
+from vSPC import settings
 
 LISTEN_BACKLOG = 128 # match the default SOMAXCONN value to max performance
 
@@ -474,6 +475,13 @@ class vSPC(Poller, VMExtHandler):
         else:
             # Act like we just learned the uuid
             vt.uuid = peer_uuid
+            if settings.SUPPORT_MULTI_CONSOLE:
+                uuid_split = peer_uuid.rsplit("_", 1)
+                if len(uuid_split) < 2:
+                    logging.error("peer uuid appears invalid. didnt find URI suffix")
+                    return False
+                vt.uri = uuid_split[-1]
+                logging.debug("set URI to %s", vt.uri)
             logging.debug("vmotion_peer, calling handle_vc_uuid for %s", vt)
             self.handle_vc_uuid(vt)
 

--- a/lib/server.py
+++ b/lib/server.py
@@ -525,7 +525,7 @@ class vSPC(Poller, VMExtHandler):
             orphans = self.orphans[:]
             orphans.sort(key=lambda uuid: self.vms[uuid].last_time,
                          reverse=True)
-            for index in xrange(min(connection_overage, len(orphans))):
+            for index in range(min(connection_overage, len(orphans))):
                 uuid = orphans[index]
                 vm = self.vms[uuid]
                 self.expire_orphan(vm)

--- a/lib/server.py
+++ b/lib/server.py
@@ -389,8 +389,12 @@ class vSPC(Poller, VMExtHandler):
         for vt in self.vms[client.uuid].vts:
             try:
                 self.send_buffered(vt, s)
+            except BrokenPipeError:
+                logging.debug('%s to %s: BrokenPipeError', client, vt,
+                              exc_info=True, stack_info=True)
+                self.abort_vm_connection(vt)
             except (EOFError, IOError, socket.error):
-                logging.debug('%s to %s: cl.socket send error', client, vt, 
+                logging.debug('%s to %s: cl.socket send error', client, vt,
                               exc_info=True, stack_info=True)
         self.add_reader(client, self.queue_new_client_data)
 

--- a/lib/server.py
+++ b/lib/server.py
@@ -340,7 +340,11 @@ class vSPC(Poller, VMExtHandler):
         neg_done = False
         try:
             neg_done = client.negotiation_done()
-        except (EOFError, IOError, socket.error):
+        except EOFError:
+            logging.debug("%s: client closed connection", client)
+            self.abort_client_connection(client)
+            return
+        except (IOError, socket.error):
             logging.debug('%s: socket error, aborting client connection',
                           client, exc_info=True, stack_info=True)
             self.abort_client_connection(client)
@@ -358,7 +362,11 @@ class vSPC(Poller, VMExtHandler):
         s = None
         try:
             s = client.read_very_lazy()
-        except (EOFError, IOError, socket.error):
+        except EOFError:
+            logging.debug("%s: client closed connection", client)
+            self.abort_client_connection(client)
+            return
+        except (IOError, socket.error):
             logging.debug('%s: socket error, aborting client connection', 
                           client, exc_info=True, stack_info=True)
             self.abort_client_connection(client)

--- a/lib/server.py
+++ b/lib/server.py
@@ -246,7 +246,7 @@ class vSPC(Poller, VMExtHandler):
 
     def abort_vm_connection(self, vt):
         if vt.uuid:
-            logging.info('VM %s (uuid %s) disconnected', vt.name, vt.uuid)
+            logging.info('%s disconnected', vt)
             if vt.uuid in self.vms:
                 if vt in self.vms[vt.uuid].vts:
                     self.vms[vt.uuid].vts.remove(vt)
@@ -260,9 +260,8 @@ class vSPC(Poller, VMExtHandler):
         try:
             neg_done = vt.negotiation_done()
         except (EOFError, IOError, socket.error):
-            logging.debug("socket error", stack_info=True, exc_info=True)
-            logging.warn('VM %s (uuid %s) experienced a socket error, '
-                         'closing socket', vt.name, vt.uuid)
+            logging.debug("%s got socket error", vt, stack_info=True, exc_info=True)
+            logging.warn('%s experienced a socket error, closing socket', vt)
             self.abort_vm_connection(vt)
             return
 
@@ -279,8 +278,7 @@ class vSPC(Poller, VMExtHandler):
         try:
             s = vt.read_very_lazy()
         except (EOFError, IOError, socket.error):
-            logging.debug("VM %s (uuid %s) got socket error", vt.name, vt.uuid,
-                          stack_info=True, exc_info=True)
+            logging.debug("%s got socket error", vt, stack_info=True, exc_info=True)
             self.abort_vm_connection(vt)
             return
 
@@ -301,7 +299,7 @@ class vSPC(Poller, VMExtHandler):
             try:
                 self.send_buffered(cl, s)
             except (EOFError, IOError, socket.error):
-                logging.debug('cl.socket send error', exc_info=True, 
+                logging.debug('%s to %s: cl.socket send error', vt, cl, exc_info=True,
                               stack_info=True)
                 self.abort_client_connection(cl)
         self.add_reader(vt, self.queue_new_vm_data)
@@ -326,8 +324,8 @@ class vSPC(Poller, VMExtHandler):
         try:
             neg_done = client.negotiation_done()
         except (EOFError, IOError, socket.error):
-            logging.debug('socket error, aborting client connection', 
-                          exc_info=True, stack_info=True)
+            logging.debug('%s: socket error, aborting client connection',
+                          client, exc_info=True, stack_info=True)
             self.abort_client_connection(client)
             return
 
@@ -344,8 +342,8 @@ class vSPC(Poller, VMExtHandler):
         try:
             s = client.read_very_lazy()
         except (EOFError, IOError, socket.error):
-            logging.debug('socket error, aborting client connection', 
-                          exc_info=True, stack_info=True)
+            logging.debug('%s: socket error, aborting client connection', 
+                          client, exc_info=True, stack_info=True)
             self.abort_client_connection(client)
             return
 
@@ -359,8 +357,8 @@ class vSPC(Poller, VMExtHandler):
             try:
                 self.send_buffered(vt, s)
             except (EOFError, IOError, socket.error):
-                logging.debug('cl.socket send error', exc_info=True,
-                              stack_info=True)
+                logging.debug('%s to %s: cl.socket send error', client, vt, 
+                              exc_info=True, stack_info=True)
         self.add_reader(client, self.queue_new_client_data)
 
     def queue_new_client_data(self, client):

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -1,0 +1,4 @@
+import os
+
+ADMIN_THREADS = int(os.environ.get("ADMIN_THREADS", "4"))
+ADMIN_CONN_TIMEOUT = float(os.environ.get("ADMIN_CONN_TIMEOUT", "0.2"))

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -2,3 +2,9 @@ import os
 
 ADMIN_THREADS = int(os.environ.get("ADMIN_THREADS", "4"))
 ADMIN_CONN_TIMEOUT = float(os.environ.get("ADMIN_CONN_TIMEOUT", "0.2"))
+
+# support VMs with more than 1 serial port. The port URI which was chosen
+# in vcenter when connecting to the vSPC will be stored, and automatically
+# appended to device name and device uuid, to identify that particular
+# serial port
+SUPPORT_MULTI_CONSOLE = os.environ.get("SUPPORT_MULTI_CONSOLE", "false").lower() == "true"

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -8,3 +8,6 @@ ADMIN_CONN_TIMEOUT = float(os.environ.get("ADMIN_CONN_TIMEOUT", "0.2"))
 # appended to device name and device uuid, to identify that particular
 # serial port
 SUPPORT_MULTI_CONSOLE = os.environ.get("SUPPORT_MULTI_CONSOLE", "false").lower() == "true"
+
+# if >= 1: only allow this many clients per VM
+VM_CLIENT_LIMIT = int(os.environ.get("VM_CLIENT_LIMIT", "0"))

--- a/lib/telnet.py
+++ b/lib/telnet.py
@@ -364,11 +364,12 @@ class TelnetServer(FixedTelnet):
                 if logger.isEnabledFor(logging.DEBUG):
                     # use list to evaluate the map, otherwise its
                     # printed as <map object at 0x...>
-                    logger.debug("timeout waiting for commands %s", list(desc))
+                    logger.debug("%s: timeout waiting for commands %s", self, 
+                                 list(desc))
                 self.unacked = []
             else:
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug("still waiting for %s", list(desc))
+                    logger.debug("%s: still waiting for %s", self, list(desc))
 
         return not self.unacked
 

--- a/lib/test.py
+++ b/lib/test.py
@@ -7,9 +7,9 @@ import socket
 import sys
 import termios
 
-from poll import Poller
-from telnet import VMTelnetProxyClient
-from util import prepare_terminal_with_flags, restore_terminal, string_dump, build_flags_ssh
+from vSPC.poll import Poller
+from vSPC.telnet import VMTelnetProxyClient
+from vSPC.util import prepare_terminal_with_flags, restore_terminal, string_dump, build_flags_ssh
 
 CLIENT_ESCAPE_CHAR = chr(29)
 

--- a/lib/test.py
+++ b/lib/test.py
@@ -63,7 +63,7 @@ class FakeVMClient(Poller):
         # echo back to server
         self.send_buffered(self.tc, s)
         while s:
-            c = s[:100]
+            c = s[:100].decode("utf-8")
             s = s[100:]
             self.destination.write(c)
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -52,4 +52,7 @@ def string_dump(s):
     """
     Translate a string into ASCII character codes & split with spaces.
     """
-    return " ".join(map(lambda x: str(ord(x)), list(s)))
+    if isinstance(s, bytes):
+        return " ".join(map(lambda x: str(x), s))
+    else:
+        return " ".join(map(lambda x: str(ord(x)), s))

--- a/util/dummy-client.py
+++ b/util/dummy-client.py
@@ -49,9 +49,12 @@ if __name__ == '__main__':
     vspc_host = args[0]
     vspc_port = int(args[1])
 
-    logger = logging.getLogger('')
+    logger_format = "%(asctime)s %(levelname)-5s [%(filename)s:%(lineno)d] %(message)s"
+    log_level = logging.DEBUG if options.debug else logging.INFO
+    logging.basicConfig(level=log_level, format=logger_format)
 
-    logger.setLevel(logging.DEBUG if options.debug else logging.INFO)
+    logger = logging.getLogger('')
+    logger.setLevel(log_level)
 
     fvm = FakeVMClient(sys.stdin, sys.stdout, options.vm_name, options.vm_uid)
     fvm.connect(vspc_host, vspc_port)

--- a/vSPCClient
+++ b/vSPCClient
@@ -74,8 +74,12 @@ def main():
 
     (options, args) = parser.parse_args()
 
+    logger_format = "%(asctime)s %(levelname)-5s [%(filename)s:%(lineno)d] %(message)s"
+    log_level = logging.DEBUG if options.debug else logging.INFO
+    logging.basicConfig(level=log_level, format=logger_format)
+
     logger = logging.getLogger('')
-    logger.setLevel(logging.DEBUG if options.debug else logging.INFO)
+    logger.setLevel(log_level)
     if options.syslog and not options.debug:
         from logging.handlers import SysLogHandler
         from logging import Formatter

--- a/vSPCClient
+++ b/vSPCClient
@@ -34,8 +34,12 @@ from vSPC.admin import AdminProtocolClient, Q_LOCK_FFAR, Q_LOCK_FFA, Q_LOCK_WRIT
 ADMIN_PORT = 13371
 
 def do_query(host, port, vm_name, lock_mode):
-    client = AdminProtocolClient(host, port, vm_name, sys.stdin, sys.stdout, lock_mode)
-    client.run()
+    client = AdminProtocolClient(host, port, vm_name, None, sys.stdin, sys.stdout, lock_mode)
+    client.run("cmd_query_vm")
+
+def do_clear_line(host, port, port_to_clear, lock_mode):
+    client = AdminProtocolClient(host, port, None, port_to_clear, sys.stdin, sys.stdout, lock_mode)
+    client.run("cmd_clear_port")
 
 def check_lock_mode(option, opt_str, value, parser):
     client_lock_mode = value
@@ -71,6 +75,8 @@ def main():
                       help="log to stdout instead of syslog")
     parser.add_option("-s", dest='remote_host', default="localhost",
                       help="vSPC server to connect to (default localhost)")
+    parser.add_option("-p", dest='port_to_clear', type=int,
+                      help="Port to clear (if performing clear port command)")
 
     (options, args) = parser.parse_args()
 
@@ -95,8 +101,14 @@ def main():
     if len(args) == 1:
         vm_name = args[0]
 
-    return do_query(options.remote_host, options.admin_port, vm_name,
-                    options.client_lock_mode)
+    # TODO: use subparsers for the different commands, instead of mixing them
+    # together like this
+    if options.port_to_clear is not None:
+        return do_clear_line(options.remote_host, options.admin_port,
+                             options.port_to_clear, options.client_lock_mode)
+    else:
+        return do_query(options.remote_host, options.admin_port, vm_name,
+                        options.client_lock_mode)
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/vSPCClient
+++ b/vSPCClient
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env -S python3 -u
 
 # Copyright 2012 Kevan A. Carstensen. All Rights Reserved
 #

--- a/vSPCServer
+++ b/vSPCServer
@@ -171,8 +171,12 @@ def main():
 
     (options, args) = parser.parse_args()
 
+    logger_format = "%(asctime)s %(levelname)-5s [%(filename)s:%(lineno)d] %(message)s"
+    log_level = logging.DEBUG if options.debug else logging.INFO
+    logging.basicConfig(level=log_level, format=logger_format)
+
     logger = logging.getLogger('')
-    logger.setLevel(logging.DEBUG if options.debug else logging.INFO)
+    logger.setLevel(log_level)
     if options.syslog and not options.debug:
         from logging.handlers import SysLogHandler
         from logging import Formatter

--- a/vSPCServer
+++ b/vSPCServer
@@ -118,7 +118,7 @@ def main():
     if "--backend" in sys.argv:
         try:
             backend_type = sys.argv[sys.argv.index("--backend") + 1]
-        except:
+        except Exception:
             pass
 
     backend = get_backend_type(backend_type)()
@@ -213,7 +213,7 @@ def main():
         logging.info("Shutdown requested on keyboard, exiting")
         backend.shutdown()
         return 0
-    except Exception as e:
+    except Exception:
         logging.exception("Top level exception caught")
         backend.shutdown()
         return 1

--- a/vSPCServer
+++ b/vSPCServer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2011 Kevan A. Carstensen. All Rights Reserved
 # Adapted from code written by Zach M. Loafman, copyright 2011 Isilon Systems.

--- a/vSPCServer
+++ b/vSPCServer
@@ -151,9 +151,6 @@ def main():
                       help="Don't daemonize")
     parser.add_option("--backend", dest='backend_type_name', default='Memory',
                       help="Name of custom backend class")
-    parser.add_option("-f", "--persist-file", dest="persist_file",
-                      help="DBM file prefix to persist mappings to (.dat/.dir may follow. "
-                      "This is shorthand for --backend File --file FILE.")
     parser.add_option("--ssl", action='store_true', default=False,
                       help='Start SSL/TLS on connections to the proxy port')
     parser.add_option("--cert", default=None,


### PR DESCRIPTION
Hello!

We have an internal fork of this repo which we are using at Cisco. This PR is to upstream the changes which were added in that fork.

This changeset adds the following features:

* support multiple serial ports for one VM
* support for exclusive (at most 1 client) access to a VMs console
* support for 'line clearing' (kick off any clients connected to a VMs console), like a terminal server

There were also some logging enhancements, particularly in `telnetlib.py`

There are some bug fixes as well, including e.g. fixing some unicode conversion issues